### PR TITLE
fix the case when prefix is longer than the string

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -212,9 +212,13 @@ inline bool stringHasSuffix(std::string const &value, std::string const &suffix)
   return std::equal(suffix.rbegin(), suffix.rend(), value.rbegin());
 }
 
-inline bool stringHasPrefix(const std::string &str, const std::string &prefix) {
-  auto res = mismatch(prefix.begin(), prefix.end(), str.begin());
-  return res.first == prefix.end();
+inline bool stringHasPrefix(const std::string& str, const std::string& prefix) {
+    if (prefix.size() <= str.size())
+    {
+        auto res = mismatch(prefix.begin(), prefix.end(), str.begin());
+        return res.first == prefix.end();
+    }
+    return false;
 }
 
 // without shared_ptr this map fails on Win machine

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -213,12 +213,10 @@ inline bool stringHasSuffix(std::string const &value, std::string const &suffix)
 }
 
 inline bool stringHasPrefix(const std::string& str, const std::string& prefix) {
-    if (prefix.size() <= str.size())
-    {
-        auto res = mismatch(prefix.begin(), prefix.end(), str.begin());
-        return res.first == prefix.end();
-    }
-    return false;
+    if (prefix.size() > str.size()) return false;
+
+    auto res = mismatch(prefix.begin(), prefix.end(), str.begin());
+    return res.first == prefix.end();
 }
 
 // without shared_ptr this map fails on Win machine


### PR DESCRIPTION
I think this bug might be bigger than the crash here but I fixed it to not crash
Image when it crashes (notice how the prefix and the str are swapped than usual in this case)
![img](https://i.imgur.com/tASiFSh.png)