### PR TITLE
Fix:Use as thirdparty lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,9 @@ option(BUILD_EXAMPLE "Build example usage" OFF)
 option(BUILD_HEADER_ONLY "Build header only" ON)
 option(BENCHMARK_DISABLED "Disable benchmarking" OFF)
 
-add_library(rbenchmark STATIC src/benchmark.cpp)
+if(NOT TARGET rbenchmark)
+    add_library(rbenchmark STATIC src/benchmark.cpp)
+endif()
 target_include_directories(rbenchmark PUBLIC "include")
 
 target_compile_definitions(rbenchmark PRIVATE $<$<BOOL:${BENCHMARK_DISABLED}>:BENCHMARK_DISABLED>)


### PR DESCRIPTION
This small fix should prevent a situation when **benchmark** is used as thirdparty library and solve this problem: https://cmake.org/cmake/help/latest/policy/CMP0002.html